### PR TITLE
Added property where user can set the minimum panning distance

### DIFF
--- a/HHPanningTableViewCell/HHPanningTableViewCell.h
+++ b/HHPanningTableViewCell/HHPanningTableViewCell.h
@@ -48,6 +48,7 @@ typedef enum {
 
 @property (nonatomic, assign)				NSInteger							directionMask;
 @property (nonatomic, assign)				BOOL								shouldBounce;
+@property (nonatomic, assign)				CGFloat								minimumPan;
 @property (nonatomic, weak)                 id<HHPanningTableViewCellDelegate>  delegate;
 
 - (BOOL)isDrawerRevealed;

--- a/HHPanningTableViewCell/HHPanningTableViewCell.m
+++ b/HHPanningTableViewCell/HHPanningTableViewCell.m
@@ -85,6 +85,9 @@ static HHPanningTableViewCellDirection HHOppositeDirection(HHPanningTableViewCel
 	if (self != nil) {
 		[self panningTableViewCellInit];
 	}
+    
+    // Note, minimum pan distance can be overridden
+    self.minimumPan = HH_PANNING_MINIMUM_PAN;
 	
     return self;
 }
@@ -437,7 +440,7 @@ static HHPanningTableViewCellDirection HHOppositeDirection(HHPanningTableViewCel
 		CGFloat totalPanX = translation.x;
 		
 		if (!self.panning) {
-			if (fabsf(totalPanX) <= HH_PANNING_MINIMUM_PAN) {
+			if (fabsf(totalPanX) <= self.minimumPan) {
 				totalPanX = 0.0f;
 			}
 			else {


### PR DESCRIPTION
Still uses the HH_PANNING_MINIMUM_PAN constant as the default panning
distance, though this can be overridden later by the user
