### PR TITLE
Enable use on iOS 5.0

### DIFF
--- a/HHPanningTableViewCell/HHPanningTableViewCell.m
+++ b/HHPanningTableViewCell/HHPanningTableViewCell.m
@@ -174,7 +174,6 @@ static HHPanningTableViewCellDirection HHOppositeDirection(HHPanningTableViewCel
 																										  action:@selector(gestureRecognizerDidPan:)];
 
 	gestureRecognizer.direction = HHDirectionPanGestureRecognizerHorizontal;
-	gestureRecognizer.delegate = self;
 
 	return gestureRecognizer;
 }


### PR DESCRIPTION
On iOS 5.0, if you -initWithTarget:action: and also -setDelegate: on
UIGestureRecognizer, you'll actually break the invocation, and the
cell won't be notified on a pan gesture.  This commit removes the
unnecessary -setDelegate: call and enables use on iOS 5.0.

For (slightly) more details, see http://stackoverflow.com/q/8535958
