### PR TITLE
Cleanup code for reloading and deleting cells with drawer open

### DIFF
--- a/HHPanningTableViewCell/HHPanningTableViewCell.h
+++ b/HHPanningTableViewCell/HHPanningTableViewCell.h
@@ -45,6 +45,7 @@ typedef enum {
 
 - (id)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString*)reuseIdentifier;
 
+- (void)cleanup;
 
 @property (nonatomic, strong)	IBOutlet	UIView*								drawerView;
 @property (nonatomic, assign)               CGFloat                             drawerOffset;

--- a/HHPanningTableViewCell/HHPanningTableViewCell.m
+++ b/HHPanningTableViewCell/HHPanningTableViewCell.m
@@ -132,21 +132,7 @@ static NSString *const												kTranslationContext		= @"translation";
 {
 	[super prepareForReuse];
 
-	self.delegate				= nil;
-
-	self.directionMask			= 0;
-	self.shouldBounce			= YES;
-
-	[self.drawerView removeFromSuperview];
-	[self.shadowView removeFromSuperview];
-
-	self.drawerRevealed			= NO;
-	self.animationInProgress	= NO;
-
-	self.translation			= 0.0f;
-	self.initialTranslation		= 0.0f;
-	self.panning				= NO;
-    self.panningInProgress      = NO;
+	[self cleanup];
 }
 
 - (UIView *)createShadowView
@@ -178,8 +164,30 @@ static NSString *const												kTranslationContext		= @"translation";
 
 - (void)dealloc
 {
+    [self cleanup];
+    
 	[self removeObserver:self forKeyPath:@"drawerRevealed" context:(__bridge void *)kDrawerRevealedContext];
 	[self removeObserver:self forKeyPath:@"translation" context:(__bridge void *)kTranslationContext];
+}
+
+- (void)cleanup {
+	self.delegate				= nil;
+    
+	self.directionMask			= 0;
+	self.shouldBounce			= YES;
+    
+	[self.drawerView removeFromSuperview];
+	[self.shadowView removeFromSuperview];
+    
+    [self.superview setNeedsDisplay];
+    
+	self.drawerRevealed			= NO;
+	self.animationInProgress	= NO;
+    
+	self.translation			= 0.0f;
+	self.initialTranslation		= 0.0f;
+	self.panning				= NO;
+    self.panningInProgress      = NO;
 }
 
 #pragma mark -


### PR DESCRIPTION
The cleanup method allows for the drawer to be deposed of correctly
when deleting a cell or reloading the table view, if you are removing a
cell please call [cell cleanup] before removing the cell.
